### PR TITLE
su: Don't forcefully add the bin symlink to the installed packages

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -17,7 +17,7 @@ LOCAL_PATH := $(my_path)
 include $(CLEAR_VARS)
 
 LOCAL_MODULE := su
-LOCAL_MODULE_TAGS := eng debug optional
+LOCAL_MODULE_TAGS := optional
 LOCAL_FORCE_STATIC_EXECUTABLE := true
 LOCAL_STATIC_LIBRARIES := libc libcutils
 LOCAL_C_INCLUDES := external/sqlite/dist
@@ -42,8 +42,6 @@ $(SYMLINKS):
 	@mkdir -p $(dir $@)
 	@rm -rf $@
 	$(hide) ln -sf ../xbin/su $@
-
-ALL_DEFAULT_INSTALLED_MODULES += $(SYMLINKS)
 
 # We need this so that the installed files could be picked up based on the
 # local module name


### PR DESCRIPTION
The LOCAL_MODULE dependency is enough to get it deployed when the
actual binary is built. Adding it to the default modules was leaving
a dangling dead symlink in cases where su isn't bundled (user builds)

Change-Id: I1364cf6537993a8b72bce8c178a7aeec080c9eb3
